### PR TITLE
publish module file in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "wgsl_reflect",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "WGSL Parser and Reflection library",
-  "module": "build/wgsl_reflect.module.js",
+  "module": "wgsl_reflect.module.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/brendan-duncan/wgsl_reflect"
   },
   "sideEffects": false,
   "files": [
-    "build/wgsl_reflect.module.js",
+    "wgsl_reflect.module.js",
     "LICENSE.md",
     "package.json",
     "README.md",
@@ -42,7 +42,7 @@
           "package.json",
           "LICENSE.md",
           "README.md",
-          "build/wgsl_reflect.module.js"
+          "wgsl_reflect.module.js"
       ]
   }
 }


### PR DESCRIPTION
Enables library users to import from a github url in their package.json files

by updating wgsl_reflect's package.json with the location of wgsl_reflect.module.js.

