### PR TITLE
Allow getting offsets and size for a structure

### DIFF
--- a/src/wgsl_reflect.js
+++ b/src/wgsl_reflect.js
@@ -240,23 +240,14 @@ export class WgslReflect {
         return { name: node.name, type: node.type, group, binding };
     }
 
-    getUniformBufferInfo(node) {
-        if (!this.isUniformVar(node))
-            return null;
-
-        let group = this.getAttribute(node, "group");
-        let binding = this.getAttribute(node, "binding");
-
-        group = group && group.value ? parseInt(group.value) : 0;
-        binding = binding && binding.value ? parseInt(binding.value) : 0;
-
+    getStructInfo(node) {
         const struct = this.getStruct(node.type);
 
         let offset = 0;
         let lastSize = 0;
         let lastOffset = 0;
         let structAlign = 0;
-        let buffer = { name: node.name, type: 'uniform', align: 0, size: 0, members: [], group, binding };
+        let buffer = { name: node.name, type: 'uniform', align: 0, size: 0, members: [] };
 
         for (let mi = 0, ml = struct.members.length; mi < ml; ++mi) {
             let member = struct.members[mi];
@@ -282,6 +273,23 @@ export class WgslReflect {
         buffer.align = structAlign;
 
         return buffer;
+    }
+
+    getUniformBufferInfo(node) {
+        if (!this.isUniformVar(node))
+            return null;
+
+        let group = this.getAttribute(node, "group");
+        let binding = this.getAttribute(node, "binding");
+
+        group = group && group.value ? parseInt(group.value) : 0;
+        binding = binding && binding.value ? parseInt(binding.value) : 0;
+
+        return {
+            ...this.getStructInfo(node),
+            group,
+            binding,
+        }
     }
 
     getTypeInfo(type) {


### PR DESCRIPTION
I'm not sure how you'd like to handle this but AFAICT there was no way to get offsets and sizes for nested structures.

My current code for doing this, after this change, is something like


```
        const reflect = new WgslReflect(shader);
        
        function showMembers(info, offset, prefix = '') {
            for (let m of info.members) {

                // I have no idea how to check if a member is a structure or base type
                // via the public API. As it is I call `getStruct` and if it returns
                // `null` then it must be a base type and not a struct?
                const struct = reflect.getStruct(m.type);

                if (struct) {
                    // it makes no sense to me to pass `m` here since `m` is a type generated
                    // by `getStructInfo`, not a type built at parse type. But it worked
                    // for my use case
                    const info = reflect.getStructInfo(m);

                    showMembers(info, m.offset, `${prefix}${m.name}.`);

                } else {

                    console.log(`${prefix}${m.name}`, 'off:', offset + m.offset, 'size:', m.size, m.type.name);
                }
            }
        }

        for (let u of reflect.uniforms) {
            const info = reflect.getUniformBufferInfo(u);
            showMembers(info, 0);
        }

```

Is there a better way?

Also, is there a way to know what types of each field are? It's not clear to me that `m.type.name` is a public API property nor if it's the right thing to be looking at.
