### PR TITLE
Allow calling `getStructInfo` with structs elements

### DIFF
--- a/src/wgsl_reflect.js
+++ b/src/wgsl_reflect.js
@@ -241,7 +241,7 @@ export class WgslReflect {
     }
 
     getStructInfo(node) {
-        const struct = this.getStruct(node.type);
+        const struct = node._type === 'struct' ? node : this.getStruct(node.type);
         if (!struct)
             return null;
 

--- a/test/tests/test_reflect.js
+++ b/test/tests/test_reflect.js
@@ -94,6 +94,17 @@ fn shuffler() { }
 
     test("struct", function(test) {
         test.equals(reflect.structs.length, 4);
+
+        const names = reflect.structs.map(s => s.name);
+        test.true(names.includes('ViewUniforms'));
+        test.true(names.includes('ModelUniforms'));
+        test.true(names.includes('VertexInput'));
+        test.true(names.includes('VertexOutput'));
+
+        test.notNull(reflect.getStructInfo(reflect.structs[0]));
+        test.notNull(reflect.getStructInfo(reflect.structs[1]));
+        test.notNull(reflect.getStructInfo(reflect.structs[2]));
+        test.notNull(reflect.getStructInfo(reflect.structs[3]));
     });
 
     test("uniforms", function(test) {


### PR DESCRIPTION
No idea if this is correct. I'm not sure what the difference is between node with `_type` and nodes with `type`.

I wanted to be able to get struct info from `WgslReflect.structs` as in

```
const r = new WgslReflect(code);
const info = r.getStructInfo(r.structs[0]);
```

As it lets me use the parser without a full shader.

```
const r = new WgslReflect('struct Foo { bar: u32; moo: vec3<f32>; }');
const info = r.getStructInfo(r.structs[0]);
```

not sure if that's a use case you wanted to support but in any case it seemed like being able to pass elemnts of `structs` to `getStructInfo` would be reasonable.