### PR TITLE
Add source maps to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "sideEffects": false,
   "files": [
     "wgsl_reflect.module.js",
+    "wgsl_reflect.module.js.map",
     "wgsl_reflect.node.js",
+    "wgsl_reflect.node.js.map",
     "LICENSE.md",
     "package.json",
     "README.md",


### PR DESCRIPTION
I'm working on a react project, and after upgrading deck.gl to `9.0.34`, I got this warning message:
```
WARNING in ./node_modules/wgsl_reflect/wgsl_reflect.module.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '<path-to-my-project>/node_modules/wgsl_reflect/wgsl_reflect.module.js.map' file: Error: ENOENT: no such file or directory, open '<path-to-my-project>/node_modules/wgsl_reflect/wgsl_reflect.module.js.map'
```

I noticed this module contains source maps, but they are not included in the files array, so I figured it would be a good idea to add them to get rid of that warning