### PR TITLE
Fix typo in error text

### DIFF
--- a/src/wgsl_parser.ts
+++ b/src/wgsl_parser.ts
@@ -1443,7 +1443,7 @@ export class WgslParser {
     } while (this._match(TokenTypes.tokens.comma));
     this._consume(
       TokenTypes.tokens.paren_right,
-      "Expected ')' for agument list"
+      "Expected ')' for argument list"
     );
 
     return args;


### PR DESCRIPTION
Change `agument` to `argument` in error message (`src/wgsl_parser.ts`).