### PR TITLE
Add GitHub Action to Auto-Build and Commit Dist Files on Source Changes

### DIFF
--- a/.github/build-dist.yml
+++ b/.github/build-dist.yml
@@ -1,0 +1,46 @@
+name: Build & Commit Dist Files
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "types/**"
+      - "rollup.config.js"
+      - "package.json"
+  workflow_dispatch: {} # manual redeploy when needed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # needed to push changes back
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build distribution
+        run: npm run build
+
+      - name: Commit built files
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add wgsl_reflect.node.js wgsl_reflect.module.js \
+                  wgsl_reflect.node.js.map wgsl_reflect.module.js.map
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+          else
+            git commit -m "chore: auto-build dist after changes"
+            git push
+          fi


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically builds and commits the distribution (`dist`) files whenever relevant source files are changed.  

## Motivation
Currently, updates to `src/` require a manual build step to regenerate `wgsl_reflect.node.js`, `wgsl_reflect.module.js`, and their corresponding source maps. This can lead to outdated build artifacts being published to npm or used in dependent projects.  

Automating this ensures:
- The `dist` files are always in sync with the latest source changes.
- Reduced manual overhead and human error.
- Immediate availability of the latest fixes and features when installing from GitHub.

> Note: The workflow should not make a redundant commit if the build files are already up to date.

---

I’m not sure if this approach aligns with the project’s workflow, so feel free to disregard if it doesn’t fit your process.