### PR TITLE
try to fix debug override

### DIFF
--- a/src/wgsl_debug.ts
+++ b/src/wgsl_debug.ts
@@ -6,7 +6,16 @@ import { Command, StatementCommand, CallExprCommand, GotoCommand, BlockCommand,
         ContinueTargetCommand, ContinueCommand, BreakCommand, BreakTargetCommand } from "./exec/command.js";
 import { StackFrame } from "./exec/stack_frame.js";
 import { ExecStack } from "./exec/exec_stack.js";
-import { ScalarData, VectorData, MatrixData, TextureData, TypedData, VoidData } from "./wgsl_ast.js";
+import {
+    ScalarData,
+    VectorData,
+    MatrixData,
+    TextureData,
+    TypedData,
+    VoidData,
+    ArrayType,
+    LiteralExpr
+} from "./wgsl_ast.js";
 
 type RuntimeStateCallbackType = () => void;
 
@@ -290,9 +299,9 @@ export class WgslDebug {
                                         // all other types
                                         // trashy, create an array size one and pull the first element, couldn't find a better way to support a ton of types.
                                         const arrayType = new ArrayType(`array<${node.type.name}>`, [], node.type, 1)
-                                        // noinspection TypeScriptValidateTypes
-                                        const index = new ArrayIndex(0);
-                                        v.value = new TypedData(entry, this._exec.getTypeInfo(arrayType)).getSubData(null, index, null);
+                                        let i32 = this._exec.getTypeInfo('i32');
+                                        const index = new AST.ArrayIndex(new AST.LiteralExpr(new ScalarData(new Int32Array([0]), i32), AST.Type.u32));
+                                        v.value = new TypedData(entry, this._exec.getTypeInfo(arrayType)).getSubData(new WgslExec(), index, null);
                                     }
                                 }
                             }

--- a/test/tests/test_debug.js
+++ b/test/tests/test_debug.js
@@ -200,6 +200,23 @@ export async function run() {
       test.equals(buffer, [1, 4, 6, 0]);
     });
 
+    await test("scalar binding", async function (test) {
+      const shader = `
+          @group(0) @binding(0) var<storage, read_write> buffer: f32;
+          @compute @workgroup_size(1)
+          fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              buffer = 42 + buffer;
+          }`;
+
+      const buffer = new Float32Array([6]);
+      const bg = {0: {0: buffer}};
+      const dbg = new WgslDebug(shader);
+      console.log('lol')
+      dbg.debugWorkgroup("main", [1, 0, 0], 4, bg);
+      while (dbg.stepNext());
+      test.equals(buffer, [48]);
+    });
+
     await test("dispatch function call", async function (test) {
       const shader = `
           fn scale(x: f32, y: f32) -> f32 {

--- a/test/tests/test_debug.js
+++ b/test/tests/test_debug.js
@@ -211,7 +211,6 @@ export async function run() {
       const buffer = new Float32Array([6]);
       const bg = {0: {0: buffer}};
       const dbg = new WgslDebug(shader);
-      console.log('lol')
       dbg.debugWorkgroup("main", [1, 0, 0], 4, bg);
       while (dbg.stepNext());
       test.equals(buffer, [48]);
@@ -238,7 +237,7 @@ export async function run() {
       dbg.stepNext(); // LET: i = id.x;
       dbg.stepNext(); // CALL: scale(buffer[i], 2.0)
       dbg.stepNext(); // RETURN: x * y
-      dbg.stepNext(); // ASSIGN: buffer[i] = <value> 
+      dbg.stepNext(); // ASSIGN: buffer[i] = <value>
 
       // Test that we only executed the [1, 0, 0] global_invocation_id.
       test.equals(buffer, [1, 4, 6, 0]);


### PR DESCRIPTION
try to fix #82

I couldn't find a generic codepath to go from an AST type to its datatype, so I created a array of size 1 and took its first value, `getSubData()` has a ton of type handling to do what I needed.