### PR TITLE
allow for storage bound scalar/vactor/matrix values

### DIFF
--- a/src/wgsl_debug.ts
+++ b/src/wgsl_debug.ts
@@ -6,7 +6,7 @@ import { Command, StatementCommand, CallExprCommand, GotoCommand, BlockCommand,
         ContinueTargetCommand, ContinueCommand, BreakCommand, BreakTargetCommand } from "./exec/command.js";
 import { StackFrame } from "./exec/stack_frame.js";
 import { ExecStack } from "./exec/exec_stack.js";
-import { ScalarData, VectorData, MatrixData, TextureData, TypedData, VoidData } from "./wgsl_ast.js";
+import { ScalarData, VectorData, MatrixData, TextureData, TypedData, VoidData, ArrayType, LiteralExpr } from "./wgsl_ast.js";
 
 type RuntimeStateCallbackType = () => void;
 
@@ -274,19 +274,27 @@ export class WgslDebug {
                                 }
                             }
                             if (found) {
+                                const typeInfo = this._exec.getTypeInfo(node.type);
                                 if (entry.texture !== undefined && entry.descriptor !== undefined) {
                                     // Texture
-                                    const textureData = new TextureData(entry.texture, this._exec.getTypeInfo(node.type), entry.descriptor,
-                                                                        entry.texture.view ?? null);
-                                    v.value = textureData;
+                                    v.value = new TextureData(entry.texture, typeInfo, entry.descriptor,
+                                        entry.texture.view ?? null);
                                 } else if (entry.uniform !== undefined) {
                                     // Uniform buffer
-                                    v.value = new TypedData(entry.uniform, this._exec.getTypeInfo(node.type));
+                                    v.value = new TypedData(entry.uniform, typeInfo);
                                 } else {
-                                    // Storage buffer
-                                    v.value = new TypedData(entry, this._exec.getTypeInfo(node.type));
+                                    if (typeInfo.isStruct || typeInfo.isArray) {
+                                        // Storage buffer
+                                        v.value = new TypedData(entry, typeInfo);
+                                    } else {
+                                        // all other types
+                                        // trashy, create an array size one and pull the first element, couldn't find a better way to support a ton of types.
+                                        const arrayType = new ArrayType(`array<${node.type.name}>`, [], node.type, 1)
+                                        let i32 = this._exec.getTypeInfo('i32');
+                                        const index = new AST.ArrayIndex(new AST.LiteralExpr(new ScalarData(new Int32Array([0]), i32), AST.Type.u32));
+                                        v.value = new TypedData(entry, this._exec.getTypeInfo(arrayType)).getSubData(new WgslExec(), index, null);
+                                    }
                                 }
-                            }
                         }
                     }
                 });
@@ -946,3 +954,4 @@ export class WgslDebug {
         }
     }
 }
+

--- a/test/tests/test_debug.js
+++ b/test/tests/test_debug.js
@@ -199,7 +199,23 @@ export async function run() {
       // Test that we only executed the [1, 0, 0] global_invocation_id.
       test.equals(buffer, [1, 4, 6, 0]);
     });
+    
+    await test("scalar binding", async function (test) {
+      const shader = `
+          @group(0) @binding(0) var<storage, read_write> buffer: f32;
+          @compute @workgroup_size(1)
+          fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+              buffer = 42 + buffer;
+          }`;
 
+      const buffer = new Float32Array([6]);
+      const bg = {0: {0: buffer}};
+      const dbg = new WgslDebug(shader);
+      dbg.debugWorkgroup("main", [1, 0, 0], 4, bg);
+      while (dbg.stepNext());
+      test.equals(buffer, [48]);
+    });
+    
     await test("dispatch function call", async function (test) {
       const shader = `
           fn scale(x: f32, y: f32) -> f32 {
@@ -228,3 +244,4 @@ export async function run() {
     });
   }, true);
 }
+


### PR DESCRIPTION
try to fix #82

I think pulling out the code that goes from an array member typeinfo to its correct `XXData` constructor out of `TypedData.getSubData()` to a reusable function could be extremely useful. But it's not really a task for a drive-by open sour PR.